### PR TITLE
Choke method implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ prompt -- Prompt for a password
 | --- | --- | --- | --- |
 | [ask] | <code>string</code> |  | prompt output |
 | [options] | <code>Object</code> |  |  |
-| [options.method] | <code>string</code> | <code>&quot;mask&quot;</code> | mask or hide |
+| [options.method] | <code>string</code> | <code>&quot;mask&quot;</code> | mask / hide / choke |
 
 **Example**  
 ```js
 let prompt = require('password-prompt')
 let password = prompt('password: ')
+let password = prompt('password: ', { method: 'mask' })
+let password = prompt('password: ', { method: 'hide' })
+let password = prompt('password: ', { method: 'choke' })
 // password: ******
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Node cross-platform password prompt.
 
-Supported Environments:
+## Supported Environments:
 
 * Unix
 * TTY or non-TTY
@@ -13,7 +13,7 @@ Supported Environments:
 * cmder
 * Console2
 
-# API Reference
+## API Reference
 prompt -- Prompt for a password
 
 **Returns**: <code>Promise.&lt;string&gt;</code> - input from user  
@@ -24,7 +24,14 @@ prompt -- Prompt for a password
 | [options] | <code>Object</code> |  |  |
 | [options.method] | <code>string</code> | <code>&quot;mask&quot;</code> | mask / hide / choke |
 
-**Example**  
+## Supported masking methods
+
+ * `mask` - Mask your password with \* after Enter (default)
+ * `hide` - Mask your password with \* immediately on input
+ * `choke` - Do not show any input
+
+## **Example**
+
 ```js
 let prompt = require('password-prompt')
 let password = prompt('password: ')
@@ -33,3 +40,4 @@ let password = prompt('password: ', { method: 'hide' })
 let password = prompt('password: ', { method: 'choke' })
 // password: ******
 ```
+

--- a/test.js
+++ b/test.js
@@ -4,13 +4,18 @@ let prompt = require('./index')
 prompt('hide: ', { method: 'hide' })
   .then(password => {
     console.log(`entered: ${password}`)
-    return prompt('notty: ', { method: 'notty' })
+    return prompt('mask: ', { method: 'mask' })
   })
   .then(password => {
     console.log(`entered: ${password}`)
-    return prompt('mask: ', { method: 'mask' })
+    return prompt('choke: ', { method: 'choke' })
+  })
+  .then(password => {
+    console.log(`entered: ${password}`)
+    return prompt('notty: ', { method: 'notty' })
   })
   .then(password => {
     console.log(`entered: ${password}`)
   })
   .catch(err => console.error(err.stack))
+


### PR DESCRIPTION
Hi!

[Issue 1](https://github.com/jdxcode/password-prompt/issues/1)
[Issue 5](https://github.com/jdxcode/password-prompt/issues/5)

Due to similar recent questions, I propose these changes to library and documentation.
I've implemented `choke` configuration param to suppress input, slightly improved README and upgraded `test.js`.